### PR TITLE
Make the mojo_system_ports_unittests target use the 'test' rule instead of 'executable'.

### DIFF
--- a/mojo/edk/system/ports/BUILD.gn
+++ b/mojo/edk/system/ports/BUILD.gn
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//testing/test.gni")
+
 source_set("ports") {
   sources = [
     "event.h",
@@ -28,9 +30,7 @@ source_set("ports") {
   ]
 }
 
-executable("mojo_system_ports_unittests") {
-  testonly = true
-
+test("mojo_system_ports_unittests") {
   sources = [
     "ports_unittest.cc",
   ]


### PR DESCRIPTION
This makes the test usable with TSAN and friends.
